### PR TITLE
Refactor plugin

### DIFF
--- a/lib/fluent/plugin/out_securelog_parser.rb
+++ b/lib/fluent/plugin/out_securelog_parser.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 class Fluent::SecurelogParserOutput < Fluent::Output
   Fluent::Plugin.register_output('securelog-parser', self)
 
@@ -21,6 +22,8 @@ class Fluent::SecurelogParserOutput < Fluent::Output
 
   def start
     super
+
+    @parser = Fluent::TextParser::RegexpParser.new(@regexp, 'time_format' => @time_format)
   end
 
   def shutdown
@@ -31,12 +34,12 @@ class Fluent::SecurelogParserOutput < Fluent::Output
 
     # value           => "# Jan 17 02:47:59 hostname sshd[10654]: Received disconnect from 0.0.0.0: 11: Bye Bye"
 
-    parser = Fluent::TextParser::RegexpParser.new(@regexp, 'time_format' => @time_format)
+    #parser = Fluent::TextParser::RegexpParser.new(@regexp, 'time_format' => @time_format)
 
-    parsed_value = parser.call(value)
+    parsed_value = @parser.call(value)
     # parsed_value    => [1358437767, {"host"=>"02:47:59", "process"=>"hostname sshd[10654]", "key"=>"Received disconnect from 0.0.0.0: 11: Bye Bye"}]
 
-    @securelog = parsed_value[1]['key']
+    parsed_value[1]['key']
     # parsed_value[0] => "1358437767"
     # @securelog      => "Received disconnect from 0.0.0.0: 11: Bye Bye"
   end
@@ -46,10 +49,10 @@ class Fluent::SecurelogParserOutput < Fluent::Output
 
       #recordの中身をkey, valueで分けない方法考えたい
       record.each do |key,value|
-        log_parse(value)
+        message = log_parse(value)
 
         #ここがアレ
-        record = {"message" => @securelog}
+        record = {"message" => message}
 
         Fluent::Engine.emit(@tag, time, record)
       end

--- a/lib/fluent/plugin/out_securelog_parser.rb
+++ b/lib/fluent/plugin/out_securelog_parser.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 class Fluent::SecurelogParserOutput < Fluent::Output
-  Fluent::Plugin.register_output('securelog-parser', self)
+  Fluent::Plugin.register_output('securelog_parser', self)
 
   # tagを書き換えたいので
   config_param :tag, :string


### PR DESCRIPTION
1. Improve peformance.
2. In fluentd plugin, all plugin use '_' to separate words.

If you don't mind, please merge this pull request!
