### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-securelog-parser.gemspec
+++ b/fluent-plugin-securelog-parser.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_development_dependency "fluentd"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
   gem.add_runtime_dependency "fluentd"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible API.
