### PR TITLE
Support label feature

### DIFF
--- a/fluent-plugin-securelog-parser.gemspec
+++ b/fluent-plugin-securelog-parser.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_development_dependency "fluentd"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
 end

--- a/lib/fluent/plugin/out_securelog_parser.rb
+++ b/lib/fluent/plugin/out_securelog_parser.rb
@@ -49,7 +49,7 @@ class Fluent::SecurelogParserOutput < Fluent::Output
 
         message = log_parse(value)
         record = {"message" => message}
-        Fluent::Engine.emit(@tag, time, record)
+        router.emit(@tag, time, record)
       end
     end
 


### PR DESCRIPTION
router.emit API causes following effect:
- Fluentd 0.10.58 or later --- Nothing to do. Equivarent to Fluent::Engine.emit.
- Fluentd 0.12.0 or later  --- Enabled label feature.
